### PR TITLE
Change CI link and project website link  for Github Repo's README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/se-edu/addressbook-level3/actions)
+[![CI Status](https://github.com/se-edu/addressbook-level3/workflows/Java%20CI/badge.svg)](https://github.com/AY2324S2-CS2103T-F10-2/tp/actions)
 
 ![Ui](docs/images/Ui.png)
 
@@ -49,5 +49,5 @@ This app is targeted towards student tutors who are more tech savvy, tapping int
 
 _Commands are designed with user ease and intuitive process flows in mind._
 
-* For the detailed documentation of this project, see the **[TuteeTally Product Website](https://ay2324s2-cs2103t-f10-1.github.io/tp/)**.
+* For the detailed documentation of this project, see the **[TuteeTally Product Website](https://ay2324s2-cs2103t-f10-2.github.io/tp/)**.
 * This project is based on the AddressBook-Level3 project created by the [SE-EDU initiative](https://se-education.org).


### PR DESCRIPTION
<img width="994" alt="image" src="https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/4d563f07-1801-447c-9acc-e71e4767ecc5">
Upon checking, i realised that our project's repo's readme still reflects the old CI link & another website. 

This PR Is to rectify the above issue and hopefully the "website-adapted" task will be marked done. 

fix #32 