### PR TITLE
Fix issue when loading from addressbook.json contains invalid Id

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -83,7 +83,7 @@ All commands are case-sensitive.
   e.g. if the command specifies `-name {NAME} -address {ADDRESS}`, `-address {ADDRESS} -name {NAME}` is also acceptable.
 
 * All id inputs in commands labelled `{ID}` can omit any leading 0s.<br>
-e.g. `1`, `01`, `000001` are all valid id inputs for the id `#000001`
+e.g. `1`, `01`, `000001`,`000000001` are all valid id inputs for the id `#000001`
 
 * All `{ID}` are by default *6 digits*. Any id that exceeds a 6 digit number (e.g. 1234567) may cause errors.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -385,9 +385,14 @@ After entering the `view -id 000001` command, the interface will update as shown
 _The display reflects the updated log entries for the student with ID #000001._
 
 
-### More features `[coming in v1.4]`
+### Editing the data file
 
-_Details coming soon ..._
+TuteeTally's data is saved automatically as a JSON file at `[JAR file location]/data/addressbook.json`. Do proceed carefully if you intend to edit this file directly.
+
+<div markdown="span" class="alert alert-warning">:exclamation: **Caution:**
+If your changes to the data file makes its format invalid, TuteeTally will discard all data and start with an empty data file at the next run. Hence, it is recommended to make a backup of the file (by copying and pasting to another location) before editing it.<br>
+Furthermore, certain edits can cause the TuteeTally to behave in unexpected and magical ways (e.g., if a value entered is outside of the acceptable range). Therefore, edit the data file only if you are confident that you can update it correctly.
+</div>
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/model/person/Id.java
+++ b/src/main/java/seedu/address/model/person/Id.java
@@ -1,11 +1,15 @@
 package seedu.address.model.person;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+
 /**
  * Represents a Person's id in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidId(String)}
  */
 public class Id {
     public static final String MESSAGE_CONSTRAINTS =
-            "Ids should only contain numbers";
+            "Ids should only contain numbers and should have the value"
+            + "between the range of 1 and 999999 (both inclusive)";
 
     public static final String VALIDATION_REGEX = "[#]";
 
@@ -28,13 +32,23 @@ public class Id {
      */
     public static boolean isValidId(String test) {
         try {
-            Integer.parseInt(test);
+            int tempTest = Integer.parseInt(test);
+            isBetweenRange(tempTest);
+        } catch (IllegalValueException e) {
+            return false;
         } catch (NumberFormatException e) {
             return false;
+
         }
         return true;
     }
 
+    private static void isBetweenRange(int testValue) throws IllegalValueException {
+        if (testValue < 1 || testValue > 999999) {
+            throw new IllegalValueException("If you're seeing this error means you've"
+                + "edited the addressbook.json and id should be between 1 and 999999");
+        }
+    }
     public int getInt() {
         int results;
         if (this.id.matches(VALIDATION_REGEX)) {

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -153,6 +153,10 @@ class JsonAdaptedPerson {
         if (!Subject.isValidSubject(subject)) {
             throw new IllegalValueException(Subject.MESSAGE_CONSTRAINTS);
         }
+
+        if (!Id.isValidId(uniqueId)) {
+            throw new IllegalValueException(Id.MESSAGE_CONSTRAINTS);
+        }
         if (uniqueId == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Id.class.getSimpleName()));
         }

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -153,12 +153,12 @@ class JsonAdaptedPerson {
         if (!Subject.isValidSubject(subject)) {
             throw new IllegalValueException(Subject.MESSAGE_CONSTRAINTS);
         }
+        if (uniqueId == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Id.class.getSimpleName()));
+        }
 
         if (!Id.isValidId(uniqueId)) {
             throw new IllegalValueException(Id.MESSAGE_CONSTRAINTS);
-        }
-        if (uniqueId == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Id.class.getSimpleName()));
         }
         if (!Payment.isValidPayment(payment)) {
             throw new IllegalValueException(Payment.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
@@ -30,7 +30,7 @@ public class AddExamCommandTest {
         Id idOfPersonToAddExam = personToAddExam.getUniqueId();
 
         String examName = "Math";
-        LocalDate examDate = LocalDate.of(2024, 4, 10);
+        LocalDate examDate = LocalDate.of(2024, 5, 10);
         LocalTime examTime = LocalTime.of(14, 0);
 
         AddExamCommand addExamCommand = new AddExamCommand(idOfPersonToAddExam.toString(), examName, examDate,

--- a/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
@@ -30,7 +30,7 @@ public class DeleteExamCommandTest {
         model.addPerson(person);
 
         String examName = "Math";
-        LocalDate examDate = LocalDate.of(2024, 4, 10);
+        LocalDate examDate = LocalDate.of(2024, 5, 10);
         Optional<LocalTime> examTime = Optional.of(LocalTime.of(14, 0));
         Exam exam = new Exam(examName, examDate, examTime, person.getName().fullName, person.getUniqueId());
 


### PR DESCRIPTION
Currently loading from addressbook.json with invalid 
- name
- phone
- email
- address
- subject
- payment
is checked and if invalid, a blank addressbook.json will be loaded. 

This PR fixes the bug when iD is edited. fixes #147 and fixes #151

This also fixes #146 as it now displays "do put a id between 1 and 999999"

![image](https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/4b9b615c-ec59-4f83-8a01-9a0539a44510)
![image](https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/6e2bce18-09f7-41e0-af64-c0a98e25c6d3)
<img width="867" alt="image" src="https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/e442969e-2963-41fc-abd0-a9b40c7172bf">

i feel this PR should be allowed as it needs to at least supports AB3, level. "If your changes to the data file makes its format invalid, AddressBook will discard all data and start with an empty data file at the next run. " and the same fix also  makes the corrects the error message for #146.

![image](https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/76d95947-cb49-4382-b60e-ff55f265daa6)

But while glancing at at the forum i came across the above. >< . so do vote if you feel this should be pull in.