### PR TITLE
Add minWidth to Label to make sure user can see ID no matter how long the name is

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,7 +27,7 @@
         </Label>
         <HBox  spacing="10">
           <Label fx:id="name" text="\$first" styleClass="cell_big_label" prefHeight="20" />
-          <Label fx:id="uniqueId" styleClass="cell_big_label"  prefHeight="20"  />
+          <Label fx:id="uniqueId" styleClass="cell_big_label"  prefHeight="20" minWidth = "70" />
         </HBox>
       </HBox>
       <FlowPane fx:id="tags" />

--- a/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
@@ -30,7 +30,7 @@ public class AddExamCommandTest {
         Id idOfPersonToAddExam = personToAddExam.getUniqueId();
 
         String examName = "Math";
-        LocalDate examDate = LocalDate.of(2024, 4, 10);
+        LocalDate examDate = LocalDate.of(2024, 5, 10);
         LocalTime examTime = LocalTime.of(14, 0);
 
         AddExamCommand addExamCommand = new AddExamCommand(idOfPersonToAddExam.toString(), examName, examDate,

--- a/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
@@ -30,7 +30,7 @@ public class DeleteExamCommandTest {
         model.addPerson(person);
 
         String examName = "Math";
-        LocalDate examDate = LocalDate.of(2024, 4, 10);
+        LocalDate examDate = LocalDate.of(2024, 5, 10);
         Optional<LocalTime> examTime = Optional.of(LocalTime.of(14, 0));
         Exam exam = new Exam(examName, examDate, examTime, person.getName().fullName, person.getUniqueId());
 


### PR DESCRIPTION
This PR Fixes #149.

This can be fixed as there is no other way for the user to see the id of the student if the name is too long .
https://github.com/nus-cs2103-AY2324S2/forum/issues/700

<img width="512" alt="image" src="https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/9f13e69a-6b7c-4a0a-8cdf-dec28fca7567">

P.S, it might seem like i just added less than 20 characters and i did, but i spent about an hour to google and research <shows my incompetency in javafx XD>