### PR TITLE
V1.4 fixpaymentissuewhenloadingfromstorage

### DIFF
--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -47,8 +47,11 @@ public class UniquePersonList implements Iterable<Person> {
         if (contains(toAdd)) {
             throw new DuplicatePersonException();
         }
+
+        Payment toAddPayment = toAdd.getPayment();
         internalList.add(toAdd);
         incrementTotalPersons();
+        incrementPayment(toAddPayment); // this is for loading from storage
     }
 
 
@@ -85,6 +88,10 @@ public class UniquePersonList implements Iterable<Person> {
         decrementTotalPersons();
     }
 
+    private void incrementPayment(Payment payment) {
+        double paymentAmount = payment.getAmount();
+        totalOwings += paymentAmount;
+    }
     private void incrementTotalPersons() {
         totalPersons++;
     }

--- a/src/main/java/seedu/address/ui/SummaryStatsWindow.java
+++ b/src/main/java/seedu/address/ui/SummaryStatsWindow.java
@@ -115,7 +115,7 @@ public class SummaryStatsWindow extends UiPart<Stage> {
 
     private void updateTotalOwingsofPersons() {
         totalOwings = logic.getTotalOwings();
-        String output = SUMMARYSTATS_MESSAGE_OWING + " " + Double.toString(totalOwings);
+        String output = String.format(SUMMARYSTATS_MESSAGE_OWING + "%.2f ", totalOwings);
         summaryMessageOwingsLabel.setText(output);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddExamCommandTest.java
@@ -30,7 +30,7 @@ public class AddExamCommandTest {
         Id idOfPersonToAddExam = personToAddExam.getUniqueId();
 
         String examName = "Math";
-        LocalDate examDate = LocalDate.of(2024, 4, 10);
+        LocalDate examDate = LocalDate.of(2024, 5, 10);
         LocalTime examTime = LocalTime.of(14, 0);
 
         AddExamCommand addExamCommand = new AddExamCommand(idOfPersonToAddExam.toString(), examName, examDate,

--- a/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteExamCommandTest.java
@@ -30,7 +30,7 @@ public class DeleteExamCommandTest {
         model.addPerson(person);
 
         String examName = "Math";
-        LocalDate examDate = LocalDate.of(2024, 4, 10);
+        LocalDate examDate = LocalDate.of(2024, 5, 10);
         Optional<LocalTime> examTime = Optional.of(LocalTime.of(14, 0));
         Exam exam = new Exam(examName, examDate, examTime, person.getName().fullName, person.getUniqueId());
 


### PR DESCRIPTION
Found a bug that the summarystats for total owings don't load from storage properly this should be allowed as this function dont work as expected.  

Also fixed the floating point arthiemetic bug when 0.1 + 0.2 != 0.3 

![image](https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/9ca22cd4-695b-4ec2-9b5c-db6388e52dce)

<img width="646" alt="image" src="https://github.com/AY2324S2-CS2103T-F10-2/tp/assets/122339963/9782b11b-4975-4e88-a43d-bb1b0b333355">

fixes #209 
fixes #184